### PR TITLE
⚡ Bolt: Optimize date formatting and sorting in cal page render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
+## 2025-03-22 - [Optimize Date Formatting in Svelte Render Loops]
+
+**Learning:** Calling `dayjs(date).format('HH:mm')` inside Svelte template iterators (like `{#each}`) creates unnecessary `dayjs` objects and adds formatting overhead for every element. For simple time formatting, native `Date` functions (`getHours()` and `getMinutes()`) perform much better without memory allocation overhead.
+**Action:** Replace `dayjs(date).format('HH:mm')` with a custom native `Date` formatting function when rendering lists of dates.

--- a/src/routes/cal/[calId]/+page.svelte
+++ b/src/routes/cal/[calId]/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import dayjs from 'dayjs';
-
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
 	import type { Impegno } from '$lib/api';
@@ -25,8 +23,14 @@
 	let showVacantOnly = $state(false);
 
 	let resources: Resource[] = $derived.by(() =>
-		pageData.aule.map((aula) => ({ id: aula.id, title: aula.descrizione }))
+		pageData.aule
+			.map((aula) => ({ id: aula.id, title: aula.descrizione }))
+			.sort((a, b) => a.title.localeCompare(b.title))
 	);
+
+	function formatTime(date: Date) {
+		return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+	}
 
 	let timelineEvents: Promise<Map<string, TimelineEvent[]>> = $derived.by(() => {
 		const newTimelineEvent = (resId: string, impegno: Impegno): TimelineEvent => ({
@@ -127,7 +131,7 @@
 							'Activity in progress'}
 					</p>
 					<p class="text-xs opacity-90 mt-1">
-						Until {dayjs(currentActivity.endTime).format('HH:mm')}
+						Until {formatTime(currentActivity.endTime)}
 					</p>
 				</div>
 			{:else}
@@ -135,7 +139,7 @@
 					<div class="badge badge-sm mb-2">VACANT</div>
 					{#if nextActivity}
 						<p class="text-xs opacity-90 mt-1">
-							Next: {dayjs(nextActivity.startTime).format('HH:mm')}
+							Next: {formatTime(nextActivity.startTime)}
 						</p>
 						<p class="text-xs opacity-75 truncate" title={nextActivity.title}>
 							{nextActivity.title}
@@ -172,9 +176,8 @@
 	{@const filteredResources = resources.filter(
 		(r) => !showVacantOnly || !getCurrentActivity(events, r.id, currentTime)
 	)}
-	{@const sortedResources = filteredResources.sort((a, b) => a.title.localeCompare(b.title))}
 	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-		{#each sortedResources as resource (resource.id)}
+		{#each filteredResources as resource (resource.id)}
 			{@render roomCard(events, resource)}
 		{/each}
 	</div>


### PR DESCRIPTION
💡 **What:** 
- Moved the `Array.prototype.sort()` for classrooms out of the Svelte template `{@const}` block and into the `$derived` state initialization for `resources`. 
- Replaced `dayjs(date).format('HH:mm')` with a simple native `Date` formatting function (`formatTime`) inside the Svelte component's render loop (`src/routes/cal/[calId]/+page.svelte`).

🎯 **Why:** 
Inside the template, the UI iterates over a filtered list of resources. The previous implementation was:
1. Re-sorting the filtered list every time the component re-rendered (e.g. every minute when `currentTime` ticks).
2. Instantiating a heavy `dayjs` object and running its parsing logic for every single resource card just to format simple hours and minutes. This causes unnecessary memory allocation overhead in a hot template loop that runs for dozens or hundreds of items.

📊 **Impact:** 
- Eliminates O(N log N) sorting overhead during render cycles. The array is sorted once upon data load ($derived), and `.filter()` naturally maintains this order.
- Substantially reduces JS memory allocation footprint and garbage collection pauses during list rendering, particularly on low-end devices, resulting in smoother list scrolling and faster updates. 

🔬 **Measurement:** 
Load `/cal/638f165a59ae3800e8297862` (or any large calendar) and profile the rendering performance. Component rendering is now mostly O(N) simple filter and string concatenations instead of O(N log N) sorts and O(N) complex object instantiations. Verify no visual regression in the `HH:mm` time format of the vacant/occupied badges.

---
*PR created automatically by Jules for task [12231225577273863256](https://jules.google.com/task/12231225577273863256) started by @VaiTon*