### PR TITLE
⚡ Bolt: [performance improvement] Pre-sort resources to avoid repeated O(n log n) sorting during render cycles

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
+## 2024-04-05 - Avoid Sorting Inside Svelte {@const} Tags Depending on Intervals
+**Learning:** In Svelte components where template logic or `{@const}` tags depend on fast-changing reactivity dependencies like interval timers (e.g., `currentTime` updating every minute), performing expensive operations like `Array.prototype.sort()` inside the template causes unneeded O(n log n) overhead on every render cycle.
+**Action:** Always hoist sorting and filtering of slow-changing data (like API responses) into `$derived` blocks, and leverage the fact that `Array.prototype.filter()` preserves array order to avoid repeated sorting.

--- a/src/routes/cal/[calId]/+page.svelte
+++ b/src/routes/cal/[calId]/+page.svelte
@@ -25,7 +25,10 @@
 	let showVacantOnly = $state(false);
 
 	let resources: Resource[] = $derived.by(() =>
-		pageData.aule.map((aula) => ({ id: aula.id, title: aula.descrizione }))
+		pageData.aule
+			.map((aula) => ({ id: aula.id, title: aula.descrizione }))
+			// Pre-sort resources alphabetically to avoid O(n log n) sorting during render cycles
+			.sort((a, b) => a.title.localeCompare(b.title))
 	);
 
 	let timelineEvents: Promise<Map<string, TimelineEvent[]>> = $derived.by(() => {
@@ -172,9 +175,8 @@
 	{@const filteredResources = resources.filter(
 		(r) => !showVacantOnly || !getCurrentActivity(events, r.id, currentTime)
 	)}
-	{@const sortedResources = filteredResources.sort((a, b) => a.title.localeCompare(b.title))}
 	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-		{#each sortedResources as resource (resource.id)}
+		{#each filteredResources as resource (resource.id)}
 			{@render roomCard(events, resource)}
 		{/each}
 	</div>


### PR DESCRIPTION
💡 **What:** Moved the resource sorting logic out of the template's `{@const}` tag and into the initial `resources` `$derived` block in `src/routes/cal/[calId]/+page.svelte`.
🎯 **Why:** The Svelte template used `currentTime` to filter the classroom availability. `currentTime` triggers a render cycle every minute. Consequently, the previous implementation resorted the filtered list on every single interval tick, leading to unnecessary O(n log n) overhead during component renders.
📊 **Impact:** Reduces CPU utilization slightly on client devices by eliminating an expensive operation that runs every 60 seconds (or immediately when user toggles 'showVacantOnly'), shifting the cost to a single sort when the page data initially loads.
🔬 **Measurement:** You can verify the performance improvement by profiling the React/Svelte component render cost when changing the "Show only vacant rooms" toggle. The render execution time should be measurably lower. Code passes `pnpm check` and tests pass smoothly.

---
*PR created automatically by Jules for task [17195996108615351184](https://jules.google.com/task/17195996108615351184) started by @VaiTon*