### PR TITLE
⚡ Bolt: Extract `sort()` from Svelte templates to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
+## 2025-04-06 - [Optimize sorting in templates]
+
+**Learning:** Svelte `{#each}` loops or `{@const}` blocks re-evaluate whenever their dependencies change, such as via bindings or regular `setInterval` triggers (like `currentTime`). Performing expensive operations like `sort()` or string manipulations inline in templates can lead to excessive processing and layout thrashing.
+**Action:** Extract sorting, filtering, and data transformations into `$derived` blocks or static variables in the `<script>` tag. This pre-computes data so the template only renders what it needs to without recalculating on every layout update.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -46,7 +46,9 @@
 
 	let eventsByResource = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+		// Pre-sort events chronologically before grouping to avoid sorting in the render loop
+		const sortedEvents = events.toSorted((a, b) => a.start.getTime() - b.start.getTime());
+		return Object.groupBy(sortedEvents, (e) => e.resourceId);
 	});
 
 	// Calculate the position of the current time line
@@ -157,7 +159,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start.valueOf() + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { CAL_MAP } from '$lib/cals';
+
+	const sortedCalendars = CAL_MAP.filter((it) => it.show ?? true).sort((a, b) =>
+		a.name.localeCompare(b.name)
+	);
 </script>
 
 <div class="prose md:mx-auto mx-4">
@@ -60,7 +64,7 @@
 
 <h2 class="text-2xl text-center font-bold mt-16 mb-4" id="calendars">Select a calendar</h2>
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-	{#each CAL_MAP.filter((it) => it.show ?? true).sort( (a, b) => a.name.localeCompare(b.name) ) as { id, name } (id)}
+	{#each sortedCalendars as { id, name } (id)}
 		<a
 			href={resolve('/cal/[calId]', { calId: id })}
 			class="card bg-base-100 transition rounded-xl border border-base-300 flex flex-col items-center justify-center p-6 text-base-content no-underline hover:bg-primary/10"

--- a/src/routes/cal/[calId]/+page.svelte
+++ b/src/routes/cal/[calId]/+page.svelte
@@ -25,7 +25,9 @@
 	let showVacantOnly = $state(false);
 
 	let resources: Resource[] = $derived.by(() =>
-		pageData.aule.map((aula) => ({ id: aula.id, title: aula.descrizione }))
+		pageData.aule
+			.map((aula) => ({ id: aula.id, title: aula.descrizione }))
+			.sort((a, b) => a.title.localeCompare(b.title))
 	);
 
 	let timelineEvents: Promise<Map<string, TimelineEvent[]>> = $derived.by(() => {
@@ -172,9 +174,8 @@
 	{@const filteredResources = resources.filter(
 		(r) => !showVacantOnly || !getCurrentActivity(events, r.id, currentTime)
 	)}
-	{@const sortedResources = filteredResources.sort((a, b) => a.title.localeCompare(b.title))}
 	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-		{#each sortedResources as resource (resource.id)}
+		{#each filteredResources as resource (resource.id)}
 			{@render roomCard(events, resource)}
 		{/each}
 	</div>


### PR DESCRIPTION
💡 **What:** Extracted `sort()` functions from Svelte UI templates and `{@const}` blocks into `<script>` context variables and `$derived` blocks across `Timeline.svelte`, `+page.svelte` (root), and `cal/[calId]/+page.svelte`. Used ES2023 `.toSorted()` for reference-safe functional sorting before grouping items.

🎯 **Why:** Svelte `{#each}` loops or `{@const}` blocks re-evaluate whenever their specific dependencies change. In components tracking intervals (e.g., `currentTime` updating every minute), inline `sort()` operations cause unnecessary string manipulations, `O(n log n)` array allocations, and trigger cascading layout recalculations even when the original dataset has not mutated.

📊 **Impact:** Completely eliminates re-sorting overhead during reactive Svelte ticks on timeline, classroom, and calendar selection pages. Reduces main thread blocking time during `currentTime` interval updates and significantly improves rendering consistency.

🔬 **Measurement:** Verify performance via Chrome DevTools Performance Profiler. Record the timeline component with a tightened `setInterval(..., 100)` trigger instead of 60000. Verify the total scripting and layout rendering times are reduced. Run tests via `pnpm test` and `pnpm run check` to ensure correctness.

---
*PR created automatically by Jules for task [2202718011224038451](https://jules.google.com/task/2202718011224038451) started by @VaiTon*