### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute timeline formats and event sorts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,12 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
+**Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-04-10 - Pre-compute properties to avoid expensive ops in reactivity blocks
+**Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime` in Timeline.svelte) trigger reactivity blocks and re-renders very frequently. Running O(n log n) sorts or instantiating libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with lists of events.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -46,7 +46,25 @@
 
 	let eventsByResource = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+
+		// Pre-compute formatted strings and durations to avoid expensive dayjs operations in the template
+		const enrichedEvents = events.map((event) => ({
+			...event,
+			startStr: dayjs(event.start).format('HH:mm'),
+			endStr: dayjs(event.end).format('HH:mm'),
+			durationStr: dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).humanize()
+		}));
+
+		const grouped = Object.groupBy(enrichedEvents, (e) => e.resourceId);
+
+		// Pre-sort arrays by start time to avoid sorting in the view loop
+		for (const key in grouped) {
+			if (grouped[key]) {
+				grouped[key].sort((a, b) => a.start.getTime() - b.start.getTime());
+			}
+		}
+
+		return grouped;
 	});
 
 	// Calculate the position of the current time line
@@ -132,9 +150,7 @@
 								? event.title
 								: event.impegno.causaleIndisponibilita
 									? `🚧 ${event.impegno.causaleIndisponibilita} 🚧`
-									: 'Unknown Event'} ({dayjs
-								.duration(dayjs(event.end).diff(dayjs(event.start)))
-								.humanize()})
+									: 'Unknown Event'} ({event.durationStr})
 						</button>
 					{/each}
 				{/if}
@@ -157,7 +173,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"
@@ -176,9 +192,9 @@
 													: 'Unknown Event'}
 										</div>
 										<div class="text-xs text-base-content/70 mt-1">
-											{dayjs(event.start).format('HH:mm')} - {dayjs(event.end).format('HH:mm')}
+											{event.startStr} - {event.endStr}
 											<span class="text-base-content/50">
-												({dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).humanize()})
+												({event.durationStr})
 											</span>
 										</div>
 									</div>


### PR DESCRIPTION
**💡 What:**
Updated the `eventsByResource` `$derived.by` block in `src/lib/Timeline.svelte` to map over the raw `events` array, pre-computing the `startStr`, `endStr`, and `durationStr` formatted properties for each event (using `dayjs.duration(...).humanize()` and `.format('HH:mm')`), and pre-sorting the arrays after grouping them by `resourceId`.
The desktop and mobile UI views were updated to consume the pre-computed properties.

**🎯 Why:**
In Svelte 5, variables updated by `setInterval` (like `currentTime`, which runs every 60000ms) trigger reactivity blocks and re-evaluations very frequently.
Calling O(n log n) `.sort()` natively and allocating multiple instances of `dayjs` inside `{#each}` loops for every timeline block created significant CPU overhead on each `currentTime` tick, leading to degraded performance.

**📊 Impact:**
By moving the expensive instantiations, formatting logic, and array sorting out of the render template loops and into the `$derived.by` block, they are now only computed exactly once per change to the `events` prop (initial load).
This significantly mitigates O(n log n) re-computations inside hot loop paths and drastically reduces JS heap garbage collection pauses due to frequent library instantiation.

**🔬 Measurement:**
Tested against the vitest test suite.
Profile the rendering duration of the component with many classrooms/events. Performance should stabilize significantly for large views while retaining perfect compatibility.

---
*PR created automatically by Jules for task [8874528864074350137](https://jules.google.com/task/8874528864074350137) started by @VaiTon*