### PR TITLE
⚡ Bolt: Pre-sort timeline events to avoid O(n log n) operations on render cycle

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,13 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-04-15 - Pre-sort elements outside {#each} blocks dependent on fast-changing timers
+
+**Learning:** Found a performance bottleneck where `.sort()` was being called directly inside an `{#each}` loop block. The `{#each}` loop was dependent on an array `resourceEvents` that wasn't itself changing rapidly, however the inner block also included logic dependent on a fast-changing timer (`currentTime`), or the loop was being re-evaluated during other state changes causing `O(n log n)` recalculation on every render cycle.
+**Action:** Pre-compute and sort arrays in `<script>` constant blocks or `$derived` / `$derived.by` blocks rather than calling array mutation/sorting methods directly in the markup `{#each}` loops.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -46,7 +46,15 @@
 
 	let eventsByResource = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+		const grouped = Object.groupBy(events, (e) => e.resourceId);
+		// Pre-sort events chronologically to avoid sorting on every render loop
+		for (const resId in grouped) {
+			const resEvents = grouped[resId];
+			if (resEvents) {
+				resEvents.sort((a, b) => a.start.getTime() - b.start.getTime());
+			}
+		}
+		return grouped;
 	});
 
 	// Calculate the position of the current time line
@@ -157,7 +165,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"


### PR DESCRIPTION
💡 What: Moved the `.sort()` operation out of the `{#each}` template block in `src/lib/Timeline.svelte` and into the `$derived.by` reactivity block where the `eventsByResource` groupings are calculated.
🎯 Why: In Svelte components containing reactivity bound to fast-changing intervals (like `currentTime`), template blocks can trigger re-evaluations frequently. Calling array mutation/sorting methods directly inside `{#each}` loops caused redundant `O(n log n)` recalculations on every render cycle.
📊 Impact: Completely eliminates the `O(n log n)` sort per resource during reactive re-renders triggered by the `currentTime` timer, substituting it with a fast pre-calculated array mapping. This guarantees smoother animations and interactions for components with high counts of resources and timeline events.
🔬 Measurement: Observe CPU load and layout thrashing over time when the page is active. Run tests and visual inspections to ensure the order of events remains strictly chronological per resource track.

---
*PR created automatically by Jules for task [13122338158008089545](https://jules.google.com/task/13122338158008089545) started by @VaiTon*