### PR TITLE
⚡ Bolt: [Remove inline mutating sorts from Svelte templates]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,12 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-04-07 - Pre-sort lists directly on Svelte 5 state using array.toSorted()
+**Learning:** Calling `array.sort()` inside Svelte 5 blocks or template causes inline mutation which breaks rendering efficiency and causes unneeded evaluation cycles, specially when the view reacts to high-frequency states like `currentTime`.
+**Action:** Always prefer `array.toSorted()` inside `$derived` expressions to create a new sorted reference outside of template rendering, leaving templates with clean `{#each array as element}` iterations.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -46,7 +46,9 @@
 
 	let eventsByResource = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+		// Pre-sort events chronologically to avoid sorting on every render loop
+		const sortedEvents = events.toSorted((a, b) => a.start.getTime() - b.start.getTime());
+		return Object.groupBy(sortedEvents, (e) => e.resourceId);
 	});
 
 	// Calculate the position of the current time line
@@ -157,7 +159,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { CAL_MAP } from '$lib/cals';
+
+	// Pre-sort calendars to avoid O(n log n) sorting on re-renders
+	const sortedCals = CAL_MAP.filter((it) => it.show ?? true).sort((a, b) =>
+		a.name.localeCompare(b.name)
+	);
 </script>
 
 <div class="prose md:mx-auto mx-4">
@@ -60,7 +65,7 @@
 
 <h2 class="text-2xl text-center font-bold mt-16 mb-4" id="calendars">Select a calendar</h2>
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-	{#each CAL_MAP.filter((it) => it.show ?? true).sort( (a, b) => a.name.localeCompare(b.name) ) as { id, name } (id)}
+	{#each sortedCals as { id, name } (id)}
 		<a
 			href={resolve('/cal/[calId]', { calId: id })}
 			class="card bg-base-100 transition rounded-xl border border-base-300 flex flex-col items-center justify-center p-6 text-base-content no-underline hover:bg-primary/10"


### PR DESCRIPTION
💡 **What:**
- Extracted sorting logic of static `CAL_MAP` array into the `<script>` block in `src/routes/+page.svelte`.
- Refactored `src/lib/Timeline.svelte`'s mobile list view by removing inline mutating `.sort()` within the `{#each}` block, instead applying `events.toSorted()` chronologically before grouping events inside the `$derived` block.

🎯 **Why:**
- Calling `.sort()` directly inside Svelte iteration templates creates $O(N \log N)$ operations on every re-render and also improperly mutates data during the render cycle.
- In `Timeline.svelte`, because the template recalculates frequently relative to `$state(currentTime)` (which ticks via an interval), this array sorting severely impacted CPU overhead during idle runtime and component thrashing.

📊 **Impact:** 
- Removes high-frequency $O(N \log N)$ calculations from UI rendering paths.
- Avoids mutating application state arrays in place during render cycles.

🔬 **Measurement:**
- Load the application and view the mobile Timeline UI while running Svelte performance dev tools. The time-to-render the template loops will drop. Memory allocation profile also flattens since the sort creates a one-time array structure rather than thrashing on timer ticks.

---
*PR created automatically by Jules for task [4435612306163386872](https://jules.google.com/task/4435612306163386872) started by @VaiTon*