### PR TITLE
⚡ Bolt: [optimize Svelte `#each` block performance]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,13 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-05-18 - [Optimize dayjs ops inside Timeline.svelte and Svelte each block in Svelte 5]
+
+**Learning:** When using variables updated by `setInterval` (like `currentTime`) in Svelte 5 templates, they trigger re-evaluations. Rendering large numbers of items using a library like `dayjs` for formatting times, or sorting event lists inline, drastically hurts performance because the allocations and calculations happen on every tick or render cycle.
+**Action:** Extract formatting properties (e.g. `HH:mm` format from `dayjs`) and logic like `.sort()` from `{#each}` loops. Perform the computation exactly once in a derived block (e.g., mapping over elements) so the template is only binding strings instead of instantiating libraries repeatedly.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -46,7 +46,27 @@
 
 	let eventsByResource = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+
+		// Pre-compute formatting and durations to avoid expensive dayjs operations in hot loops
+		const enhancedEvents = events.map((e) => {
+			const startD = dayjs(e.start);
+			const endD = dayjs(e.end);
+			return {
+				...e,
+				formattedStart: startD.format('HH:mm'),
+				formattedEnd: endD.format('HH:mm'),
+				humanDuration: dayjs.duration(endD.diff(startD)).humanize()
+			};
+		});
+
+		const grouped = Object.groupBy(enhancedEvents, (e) => e.resourceId);
+
+		// Pre-sort events chronologically to prevent inline mutations inside rendering logic
+		for (const key in grouped) {
+			grouped[key]?.sort((a, b) => a.start.getTime() - b.start.getTime());
+		}
+
+		return grouped;
 	});
 
 	// Calculate the position of the current time line
@@ -132,9 +152,7 @@
 								? event.title
 								: event.impegno.causaleIndisponibilita
 									? `🚧 ${event.impegno.causaleIndisponibilita} 🚧`
-									: 'Unknown Event'} ({dayjs
-								.duration(dayjs(event.end).diff(dayjs(event.start)))
-								.humanize()})
+									: 'Unknown Event'} ({event.humanDuration})
 						</button>
 					{/each}
 				{/if}
@@ -157,7 +175,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"
@@ -176,9 +194,9 @@
 													: 'Unknown Event'}
 										</div>
 										<div class="text-xs text-base-content/70 mt-1">
-											{dayjs(event.start).format('HH:mm')} - {dayjs(event.end).format('HH:mm')}
+											{event.formattedStart} - {event.formattedEnd}
 											<span class="text-base-content/50">
-												({dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).humanize()})
+												({event.humanDuration})
 											</span>
 										</div>
 									</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { CAL_MAP } from '$lib/cals';
+
+	const activeCalendars = CAL_MAP.filter((it) => it.show ?? true).sort((a, b) =>
+		a.name.localeCompare(b.name)
+	);
 </script>
 
 <div class="prose md:mx-auto mx-4">
@@ -60,7 +64,7 @@
 
 <h2 class="text-2xl text-center font-bold mt-16 mb-4" id="calendars">Select a calendar</h2>
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-	{#each CAL_MAP.filter((it) => it.show ?? true).sort( (a, b) => a.name.localeCompare(b.name) ) as { id, name } (id)}
+	{#each activeCalendars as { id, name } (id)}
 		<a
 			href={resolve('/cal/[calId]', { calId: id })}
 			class="card bg-base-100 transition rounded-xl border border-base-300 flex flex-col items-center justify-center p-6 text-base-content no-underline hover:bg-primary/10"


### PR DESCRIPTION
💡 What: 
- Extracts `dayjs` formatting strings to the `$derived` mapping block outside the Svelte template render `{#each}` loop in `Timeline.svelte` (desktop/mobile).
- Pre-sorts `grouped` timelines securely instead of mutating array structure in hot loops.
- Moves the constant layout `CAL_MAP.filter().sort()` from the Svelte template `+page.svelte` to script init.

🎯 Why: 
In Svelte 5, items updated by timers or fast interactions (like `setInterval` driving `currentTime`) easily trigger template re-renders. Re-sorting arrays in line inside loops mutates them recursively, preventing optimizations. In addition, creating instances of utility objects like `dayjs(event.start)` for formatting on every tick during a large mapping operation induces considerable GC (garbage collection) and CPU overhead on lower-end devices. 

📊 Impact: 
- Eliminates `dayjs` instance allocations for hundreds of event nodes inside re-renders. 
- Avoids mutating list arrays directly in the template binding phase, dropping CPU rendering time severely in hot-path elements tied to internal timers.
- Stops repeated list generation mapping in statically defined page routes. 

🔬 Measurement: 
To verify, you can monitor browser performance tab memory allocations over a multi-minute profile. Without these changes, rendering thousands of `div` tags per minute repeatedly allocating Date contexts is visible. 

Additionally, `.jules/bolt.md` is updated to help document `setInterval` induced re-render pitfalls within Svelte loops.

---
*PR created automatically by Jules for task [6115268095067331140](https://jules.google.com/task/6115268095067331140) started by @VaiTon*