### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute timeline dates and sorts out of render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,13 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-04-21 - Avoid inline array mutation (sorting) and expensive library instantiation in Svelte `{#each}` loops
+
+**Learning:** Using `array.sort()` directly inside Svelte 5 `{#each}` loop expressions mutates the array in-place. When this loop references a fast-changing reactive variable (such as `currentTime` updated by `setInterval`), the array is sorted on every single tick, leading to CPU overhead and rendering inefficiencies. Also, calling `dayjs()` inside these loops repeatedly creates expensive date instances.
+**Action:** Pre-compute derived strings using mapping within `$derived` blocks. Pre-sort data chronologically using `.toSorted()` or in a `$derived` block outside of template rendering, so the loop simply iterates over pre-sorted, pre-formatted data.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -44,9 +44,30 @@
 		return resources.toSorted((a, b) => a.title.localeCompare(b.title));
 	});
 
+	let processedEvents = $derived.by(() => {
+		if (!events) return [];
+		return events.map((event) => {
+			const startDayjs = dayjs(event.start);
+			const endDayjs = dayjs(event.end);
+			return {
+				...event,
+				durationHuman: dayjs.duration(endDayjs.diff(startDayjs)).humanize(),
+				startFormatted: startDayjs.format('HH:mm'),
+				endFormatted: endDayjs.format('HH:mm')
+			};
+		});
+	});
+
 	let eventsByResource = $derived.by(() => {
-		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+		if (!processedEvents) return {};
+		const grouped = Object.groupBy(processedEvents, (e) => e.resourceId);
+
+		// Pre-sort events chronologically to avoid sorting inside template loops
+		for (const key in grouped) {
+			grouped[key]?.sort((a, b) => a.start.getTime() - b.start.getTime());
+		}
+
+		return grouped;
 	});
 
 	// Calculate the position of the current time line
@@ -132,9 +153,7 @@
 								? event.title
 								: event.impegno.causaleIndisponibilita
 									? `🚧 ${event.impegno.causaleIndisponibilita} 🚧`
-									: 'Unknown Event'} ({dayjs
-								.duration(dayjs(event.end).diff(dayjs(event.start)))
-								.humanize()})
+									: 'Unknown Event'} ({event.durationHuman})
 						</button>
 					{/each}
 				{/if}
@@ -157,7 +176,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"
@@ -176,9 +195,9 @@
 													: 'Unknown Event'}
 										</div>
 										<div class="text-xs text-base-content/70 mt-1">
-											{dayjs(event.start).format('HH:mm')} - {dayjs(event.end).format('HH:mm')}
+											{event.startFormatted} - {event.endFormatted}
 											<span class="text-base-content/50">
-												({dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).humanize()})
+												({event.durationHuman})
 											</span>
 										</div>
 									</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { CAL_MAP } from '$lib/cals';
+
+	// Pre-filter and pre-sort calendars to avoid re-evaluation on re-renders
+	const sortedCals = CAL_MAP.filter((it) => it.show ?? true).toSorted((a, b) =>
+		a.name.localeCompare(b.name)
+	);
 </script>
 
 <div class="prose md:mx-auto mx-4">
@@ -60,7 +65,7 @@
 
 <h2 class="text-2xl text-center font-bold mt-16 mb-4" id="calendars">Select a calendar</h2>
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-	{#each CAL_MAP.filter((it) => it.show ?? true).sort( (a, b) => a.name.localeCompare(b.name) ) as { id, name } (id)}
+	{#each sortedCals as { id, name } (id)}
 		<a
 			href={resolve('/cal/[calId]', { calId: id })}
 			class="card bg-base-100 transition rounded-xl border border-base-300 flex flex-col items-center justify-center p-6 text-base-content no-underline hover:bg-primary/10"


### PR DESCRIPTION
💡 What: Optimized timeline event processing by lifting computationally expensive operations (`array.sort()` and `dayjs()` instantiations) out of Svelte `{#each}` loop rendering paths into `$derived` pre-computations. Also pre-sorted `CAL_MAP` on the main page.
🎯 Why: Because `currentTime` updates every minute (triggering reactive re-evaluations), and mobile views rerendered all resource items, inline sorting and formatting caused unnecessary CPU overhead, array mutation, and garbage collection pressure.
📊 Impact: Eliminates `O(n log n)` inline sorts and expensive `dayjs` object allocations per render cycle, significantly improving the timeline's responsiveness and saving battery power, especially when the current time ticker runs.
🔬 Measurement: Verify by interacting with the timeline or waiting for the minute-ticker; observe lower CPU usage in Chrome DevTools Performance tab. Ensure all timeline views and calendar filters correctly sort alphabetically and chronologically.

---
*PR created automatically by Jules for task [8902465758266553360](https://jules.google.com/task/8902465758266553360) started by @VaiTon*