### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute properties in Timeline.svelte

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,13 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-04-18 - [Optimize Events Mapping in Timeline.svelte]
+
+**Learning:** Inline array sort and instantiating 'dayjs' within Svelte 'each' blocks or fast-updating templates cause significant allocation and computation overhead leading to poor render performance.
+**Action:** Pre-compute formats and pre-sort chronologically in the derived block. Since filtering occurs first, the derived block maps values accurately before they render.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -46,7 +46,30 @@
 
 	let eventsByResource = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+		// Pre-compute formatted strings to avoid calling dayjs repeatedly during template render,
+		// especially since currentTime updates frequently.
+		const optimizedEvents = events.map((e) => {
+			const dStart = dayjs(e.start);
+			const dEnd = dayjs(e.end);
+			return {
+				...e,
+				formattedStart: dStart.format('HH:mm'),
+				formattedEnd: dEnd.format('HH:mm'),
+				humanDuration: dayjs.duration(dEnd.diff(dStart)).humanize()
+			};
+		});
+
+		const grouped = Object.groupBy(optimizedEvents, (e) => e.resourceId);
+
+		// Pre-sort arrays chronologically to remove the inline .sort() in the mobile template
+		for (const key in grouped) {
+			const resEvents = grouped[key];
+			if (resEvents) {
+				resEvents.sort((a, b) => a.start.getTime() - b.start.getTime());
+			}
+		}
+
+		return grouped;
 	});
 
 	// Calculate the position of the current time line
@@ -120,24 +143,20 @@
 					<div class="flex-1 h-12 border-l border-base-300"></div>
 				{/each}
 				<!-- Render events for this resource -->
-				{#if events}
-					{#each eventsByResource[resource.id] || [] as event (event.start + event.title)}
-						<button
-							class="absolute top-2 h-8 bg-primary text-primary-content rounded shadow flex items-center px-2 text-xs font-semibold overflow-hidden whitespace-nowrap truncate cursor-pointer"
-							style={getEventSpanStyle(event.start, event.end)}
-							title={event.title}
-							onclick={() => onEventClick?.(event.impegno)}
-						>
-							{event.title
-								? event.title
-								: event.impegno.causaleIndisponibilita
-									? `🚧 ${event.impegno.causaleIndisponibilita} 🚧`
-									: 'Unknown Event'} ({dayjs
-								.duration(dayjs(event.end).diff(dayjs(event.start)))
-								.humanize()})
-						</button>
-					{/each}
-				{/if}
+				{#each eventsByResource[resource.id] || [] as event (String(event.start.getTime()) + (event.title || ''))}
+					<button
+						class="absolute top-2 h-8 bg-primary text-primary-content rounded shadow flex items-center px-2 text-xs font-semibold overflow-hidden whitespace-nowrap truncate cursor-pointer"
+						style={getEventSpanStyle(event.start, event.end)}
+						title={event.title}
+						onclick={() => onEventClick?.(event.impegno)}
+					>
+						{event.title
+							? event.title
+							: event.impegno.causaleIndisponibilita
+								? `🚧 ${event.impegno.causaleIndisponibilita} 🚧`
+								: 'Unknown Event'} ({event.humanDuration})
+					</button>
+				{/each}
 			</div>
 		{/each}
 	</div>
@@ -157,7 +176,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (String(event.start.getTime()) + (event.title || ''))}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"
@@ -176,9 +195,9 @@
 													: 'Unknown Event'}
 										</div>
 										<div class="text-xs text-base-content/70 mt-1">
-											{dayjs(event.start).format('HH:mm')} - {dayjs(event.end).format('HH:mm')}
+											{event.formattedStart} - {event.formattedEnd}
 											<span class="text-base-content/50">
-												({dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).humanize()})
+												({event.humanDuration})
 											</span>
 										</div>
 									</div>


### PR DESCRIPTION
💡 **What:** Moved `dayjs` instantiations and formatting strings into the Svelte `$derived.by` callback in `Timeline.svelte`. Pre-sorted the array by start time instead of calling `array.sort()` inside Svelte's `{#each}` loop on the mobile view.
🎯 **Why:** Computations directly inside Svelte 5 blocks are executed continuously (layout thrashing) on variables like `currentTime` (updated by `setInterval`). Doing object allocations inside these blocks creates CPU overhead on each render.
📊 **Impact:** Speeds up timeline component render and removes micro-lag occurring on updates by computing formats per event just once on data load.
🔬 **Measurement:** Open DevTools Profiler and observe CPU frame times when timeline renders and updates per minute - fewer JS function calls for formatting.

---
*PR created automatically by Jules for task [11553372825486800857](https://jules.google.com/task/11553372825486800857) started by @VaiTon*