### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute formatting and sorting in Timeline.svelte

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,6 +12,13 @@
 
 **Learning:** Performing `O(n log n)` array sorting and `O(n)` string concatenations/lowercasing inside Svelte component render cycles (e.g. inside a `$derived` or `{@const}` block dependent on fast-changing user input) causes severe performance degradation and layout thrashing, as it reruns every keystroke.
 **Action:** Pre-compute lowercase search keys and pre-sort arrays in the `+page.ts` load function before passing data to the Svelte component. Use `$derived` for just lowercasing the search query once per keystroke, and perform a simple `O(n)` filter using `.includes()` in the template.
+
 ## 2025-04-07 - Pre-compute properties to avoid expensive ops in reactivity blocks
+
 **Learning:** In Svelte 5, variables updated by `setInterval` (like `currentTime`) trigger reactivity blocks (like `{@const}`) and re-renders very frequently. Running O(n log n) sorts or creating instances of libraries like `dayjs` within these reactive templates creates significant CPU overhead, especially with large lists like classrooms.
 **Action:** Always pre-compute formats (e.g., `dayjs` strings) and pre-sort lists once inside `$derived` or initial data loading. Filter operations are cheap, but sorts and object allocations should be moved out of the hot path.
+
+## 2025-04-26 - Precompute Dayjs Formats in `$derived.by` for Svelte 5 Lists
+
+**Learning:** In Svelte 5, using inline `array.sort()` and repeated `dayjs` formatting inside a `{#each}` loop block incurs significant performance overhead, especially on larger datasets. Mutating sorts like `array.sort()` inside Svelte rendering templates can also break rendering efficiency.
+**Action:** Always pre-compute and format the derived list data (e.g. sorted arrays and formatted string properties using `.toSorted()`) inside the `<script>` block, inside `$derived` or `$derived.by`, avoiding direct array mutations and repeated expensive calculations inside the template itself.

--- a/src/lib/Timeline.svelte
+++ b/src/lib/Timeline.svelte
@@ -44,9 +44,40 @@
 		return resources.toSorted((a, b) => a.title.localeCompare(b.title));
 	});
 
-	let eventsByResource = $derived.by(() => {
+	let eventsByResource: Record<
+		string,
+		(NonNullable<Props['events']>[0] & {
+			humanDuration: string;
+			formattedStart: string;
+			formattedEnd: string;
+		})[]
+	> = $derived.by(() => {
 		if (!events) return {};
-		return Object.groupBy(events, (e) => e.resourceId);
+
+		const grouped = Object.groupBy(events, (e) => e.resourceId);
+
+		for (const key in grouped) {
+			const group = grouped[key];
+			if (group) {
+				grouped[key] = group
+					.toSorted((a, b) => a.start.getTime() - b.start.getTime())
+					.map((event) => ({
+						...event,
+						humanDuration: dayjs.duration(event.end.getTime() - event.start.getTime()).humanize(),
+						formattedStart: dayjs(event.start).format('HH:mm'),
+						formattedEnd: dayjs(event.end).format('HH:mm')
+					}));
+			}
+		}
+
+		return grouped as unknown as Record<
+			string,
+			(NonNullable<Props['events']>[0] & {
+				humanDuration: string;
+				formattedStart: string;
+				formattedEnd: string;
+			})[]
+		>;
 	});
 
 	// Calculate the position of the current time line
@@ -132,9 +163,7 @@
 								? event.title
 								: event.impegno.causaleIndisponibilita
 									? `🚧 ${event.impegno.causaleIndisponibilita} 🚧`
-									: 'Unknown Event'} ({dayjs
-								.duration(dayjs(event.end).diff(dayjs(event.start)))
-								.humanize()})
+									: 'Unknown Event'} ({event.humanDuration})
 						</button>
 					{/each}
 				{/if}
@@ -157,7 +186,7 @@
 				</a>
 				{#if resourceEvents.length > 0}
 					<div class="divide-y divide-base-300">
-						{#each resourceEvents.sort((a, b) => a.start.getTime() - b.start.getTime()) as event (event.start + event.title)}
+						{#each resourceEvents as event (event.start.valueOf() + event.title)}
 							{@const isNow = currentTime >= event.start && currentTime <= event.end}
 							<button
 								class="w-full text-left px-4 py-3 hover:bg-base-200 transition"
@@ -176,9 +205,9 @@
 													: 'Unknown Event'}
 										</div>
 										<div class="text-xs text-base-content/70 mt-1">
-											{dayjs(event.start).format('HH:mm')} - {dayjs(event.end).format('HH:mm')}
+											{event.formattedStart} - {event.formattedEnd}
 											<span class="text-base-content/50">
-												({dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).humanize()})
+												({event.humanDuration})
 											</span>
 										</div>
 									</div>


### PR DESCRIPTION
💡 What: Moved `dayjs` formatting (`formattedStart`, `formattedEnd`, `humanDuration`) and event sorting (`toSorted`) out of the Svelte template (`{#each}` loop) and into the `$derived.by` reactivity block in `src/lib/Timeline.svelte`.
🎯 Why: In Svelte 5, variables updated by `setInterval` (like `currentTime` in this component) trigger template re-renders very frequently. Running `array.sort()` and instantiating `dayjs` objects inside the `{#each}` block caused high CPU overhead and unnecessary allocations on every minute tick.
📊 Impact: Eliminates expensive object instantiations and sorting during render cycles, replacing them with simple property lookups. Reduces template re-render time significantly, especially on mobile views with many events.
🔬 Measurement: Verify by rendering a timeline with many events on mobile view, checking performance metrics during minute updates (when `currentTime` changes). The CPU spikes should be vastly reduced.

---
*PR created automatically by Jules for task [4204487136187977856](https://jules.google.com/task/4204487136187977856) started by @VaiTon*